### PR TITLE
Changed plot_stamps from html to matplotlib, changed mask to psf

### DIFF
--- a/alerce/common_stamps.py
+++ b/alerce/common_stamps.py
@@ -76,7 +76,7 @@ class AlerceCommonStamps:
         oid,
         candid=None,
         measurement_id=None,
-        include_variance_and_mask=False,  # NEW
+        include_variance_and_psf=False,
         format="HDUList",
         survey=None,
     ):
@@ -98,7 +98,7 @@ class AlerceCommonStamps:
             The survey to query. If None, defaults to 'ztf'. Note: relying on
             the default (omitting the `survey` parameter) is deprecated and will be removed in
             a future release; callers should explicitly pass the desired survey (e.g. `survey='ztf'`).
-        include_variance_and_mask : bool
+        include_variance_and_psf : bool
             If True, returns extra planes of the image cutouts.
         Returns
         -------
@@ -129,7 +129,7 @@ class AlerceCommonStamps:
             return self.multisurvey_stamps_client.multisurvey_get_stamps(
                 oid=oid,
                 candid=candid,
-                include_variance_and_mask=include_variance_and_mask,
+                include_variance_and_psf=include_variance_and_psf,
                 survey=survey,
             )
         else:

--- a/alerce/ms_stamp_utils.py
+++ b/alerce/ms_stamp_utils.py
@@ -10,22 +10,3 @@ def create_stamp_parameters(oid, survey, measurement_id, stamp_type, avro_url, c
             avro_url
             + f"?oid={oid}&measurement_id={measurement_id}&stamp_type={stamp_type}&file_format=fits&survey_id={survey}"
         )
-
-
-def create_html_stamp_display(
-    oid, survey, measurement_id, science, template, difference
-):
-    return f"""
-        <div> {survey.upper()} oid:{oid}, measurement_id:{measurement_id} </div>
-        <div>&emsp;&emsp;&emsp;&emsp;&emsp;
-        Science
-        &emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;
-        Template
-        &emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;
-        Difference
-        <div class="container">
-            <div style="float:left;width:20%"><img src="{science}"></div>
-            <div style="float:left;width:20%"><img src="{template}"></div>
-            <div style="float:left;width:20%"><img src="{difference}"></div>
-        </div>
-        """

--- a/alerce/ms_stamps.py
+++ b/alerce/ms_stamps.py
@@ -6,8 +6,9 @@ from astropy.io.fits import open as fits_open
 from urllib.error import HTTPError
 from alerce.ms_search import AlerceSearchMultiSurvey
 from alerce.exceptions import CandidError
-from .ms_stamp_utils import create_html_stamp_display, create_stamp_parameters
-from IPython.display import HTML, display
+from .ms_stamp_utils import create_stamp_parameters
+import matplotlib.pyplot as plt
+from PIL import Image
 
 VALID_SURVEYS = ["lsst", "ztf"]
 
@@ -84,31 +85,45 @@ class AlerceStampsMultisurvey(Client):
 
         avro_url = self.config["STAMP_URL"] + self.config["AVRO_ROUTES"]["get_stamp"]
 
-        science_url = create_stamp_parameters(
-            oid, survey, measurement_id, self.ztf_types["science"], avro_url, "plot"
-        )
-        template_url = create_stamp_parameters(
-            oid, survey, measurement_id, self.ztf_types["template"], avro_url, "plot"
-        )
-        difference_url = create_stamp_parameters(
-            oid, survey, measurement_id, self.ztf_types["difference"], avro_url, "plot"
-        )
-
         if not self._in_ipynb():
             warnings.warn("This method only works on Notebooks", RuntimeWarning)
             return
 
-        images = create_html_stamp_display(
-            oid, survey, measurement_id, science_url, template_url, difference_url
+        image_types = ["Science", "Template", "Difference"]
+        title = (
+            survey.upper()
+            + " oid:"
+            + str(oid)
+            + ", measurement_id:"
+            + str(measurement_id)
         )
-        display(HTML(images))
+        fig, ax = plt.subplots(figsize=[9, 5], ncols=3)
+        fig.suptitle(title, fontsize=10, y=0.82)
+
+        for i, image_type in enumerate(image_types):
+            url = create_stamp_parameters(
+                oid,
+                survey,
+                measurement_id,
+                self.ztf_types[image_type.lower()],
+                avro_url,
+                "plot",
+            )
+            http_response = self.session.request("GET", url)
+            data = http_response.content
+
+            ax[i].imshow(Image.open(io.BytesIO(data)))
+            ax[i].set_title(image_type, fontsize=10)
+            ax[i].axis("off")
+
+        plt.subplots_adjust(wspace=0.0)
 
     def multisurvey_get_stamps(
         self,
         survey,
         oid,
         candid=None,
-        include_variance_and_mask=False,
+        include_variance_and_psf=False,
         out_format="HDUList",
     ):
         """Download Stamps for an specific alert given oid and survey, measurement_id is optional."""
@@ -145,7 +160,7 @@ class AlerceStampsMultisurvey(Client):
                     io.BytesIO(fits_buffer.read()), ignore_missing_simple=True
                 )
 
-                if include_variance_and_mask:
+                if include_variance_and_psf:
                     stamp_list.append(tmp_hdulist)
                 else:
                     stamp_list.append(tmp_hdulist[0])

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ pandas>=1.1.2
 astropy>=4.0.1
 requests>=2.24.0
 ipython
+matplotlib


### PR DESCRIPTION
## Description
This PR changes the multisurvey plot_stamps function from html to matplotlib, because of known problems of the html display on notebooks shown in github and colab. It also renames the include_variance_and_mask flag to include_variance_and_psf, because the third image cutouts plane is PSF and not a mask.

## How Has This Been Tested?
Manually in example notebooks