### PR TITLE
Move URL for 'query_forced_photometry' to config

### DIFF
--- a/alerce/default_config.json
+++ b/alerce/default_config.json
@@ -25,6 +25,30 @@
             "single_feature": "/objects/%s/features/%s",
             "classifiers": "/classifiers",
             "classifier_classes": "/classifiers/%s/%s/classes"
+        },
+        "VERSIONS": {
+          "V1": {
+            "ZTF_API_URL": "https://api.alerce.online/ztf/v1/",
+            "ZTF_ROUTES": {
+                "objects": "/objects",
+                "single_object": "/objects/%s",
+                "detections": "/objects/%s/detections",
+                "non_detections": "/objects/%s/non_detections",
+                "lightcurve": "/objects/%s/lightcurve",
+                "magstats": "/objects/%s/magstats",
+                "probabilities": "/objects/%s/probabilities",
+                "features": "/objects/%s/features",
+                "single_feature": "/objects/%s/features/%s",
+                "classifiers": "/classifiers",
+                "classifier_classes": "/classifiers/%s/%s/classes"
+            }
+          },
+          "V2": {
+            "ZTF_API_URL": "https://api.alerce.online/v2/",
+            "ZTF_ROUTES": {
+                "forced_photometry": "lightcurve/forced-photometry/%s"
+            }
+          }
         }
     },
     "stamps": {

--- a/alerce/ztf_search.py
+++ b/alerce/ztf_search.py
@@ -11,12 +11,24 @@ class ZTFSearch(Client):
         cfg = load_config(service="ztf")
         super().__init__(**cfg)
 
-    @property
-    def ztf_url(self):
-        return self.config["ZTF_API_URL"]
+    def __get_url(self, resource, *args, **kwargs):
+        """
+        Retrieves the base URL and endpoint for a given key.
+        Allows specifying a version via kwargs (see default_config.json).
+        """
 
-    def __get_url(self, resource, *args):
-        return self.ztf_url + self.config["ZTF_ROUTES"][resource] % args
+        config_for_version = self.config
+
+        if "version" in kwargs:
+            api_version = kwargs["version"]
+            config_for_version = self.config["VERSIONS"][api_version]
+
+        BASE_URL = config_for_version["ZTF_API_URL"]
+        ROUTES = config_for_version["ZTF_ROUTES"]
+        ROUTE = ROUTES[resource]
+        FULL_URL = BASE_URL + ROUTE % args
+
+        return FULL_URL
 
     def query_objects(self, format="pandas", index=None, sort=None, **kwargs):
         """
@@ -162,12 +174,9 @@ class ZTFSearch(Client):
         """
         q = self._request(
             "GET",
-            "https://api.alerce.online/v2/lightcurve/forced-photometry/%s" % oid,
-            result_format=format,
+            self.__get_url("forced_photometry", oid, version="V2"), 
+            result_format=format
         )
-
-        # NOTA: la api principal de ztf no tiene ruta de forced photometry, la v2 si tiene. Esto es lo mas facil
-        # pero no es correcto.
 
         # all this extra code is to expand the extra fields.
         complete_result = q.result(index, sort)


### PR DESCRIPTION
## Description
This PR moves the construction of the URL for the method `query_forced_photometry` to the JSON config file. Most of the methods already use the config file but this one does not. We intended to use the config for an integration test but this issue blocks that.

This change required some changes to the way the config is structured.
There is some duplicate information now in the config but doing it this way should not break existing configs.

## Related Issue or Feature
Fixes #74 

## Motivation and Context
This fixes #74. Motivation is outlined there.

## How Has This Been Tested?
I ran the test suite and all tests passed EXCEPT for the following 2 that should not be affected by the change:

```sh
FAILED tests/integration/test_query_objects.py::test_query_objects_lsst_multisurvey_1 - alerce.exceptions.APIError: {'Error code': 500, 'Message': 'An error occurred', 'Data': {}}
FAILED tests/integration/test_query_objects.py::test_query_objects_lsst_multisurvey_classifier_without_class_name - alerce.exceptions.APIError: {'Error code': 500, 'Message': 'An error occurred', 'Data': {}}
```