### PR TITLE
Move forced_photometry url to default config

### DIFF
--- a/alerce/default_config.json
+++ b/alerce/default_config.json
@@ -12,19 +12,20 @@
         }
     },
     "ztf": {
-        "ZTF_API_URL": "https://api.alerce.online/ztf/v1/",
+        "ZTF_API_URL": "https://api.alerce.online",
         "ZTF_ROUTES": {
-            "objects": "/objects",
-            "single_object": "/objects/%s",
-            "detections": "/objects/%s/detections",
-            "non_detections": "/objects/%s/non_detections",
-            "lightcurve": "/objects/%s/lightcurve",
-            "magstats": "/objects/%s/magstats",
-            "probabilities": "/objects/%s/probabilities",
-            "features": "/objects/%s/features",
-            "single_feature": "/objects/%s/features/%s",
-            "classifiers": "/classifiers",
-            "classifier_classes": "/classifiers/%s/%s/classes"
+            "objects": "/ztf/v1/objects",
+            "single_object": "/ztf/v1/objects/%s",
+            "detections": "/ztf/v1/objects/%s/detections",
+            "non_detections": "/ztf/v1/objects/%s/non_detections",
+            "lightcurve": "/ztf/v1/objects/%s/lightcurve",
+            "magstats": "/ztf/v1/objects/%s/magstats",
+            "probabilities": "/ztf/v1/objects/%s/probabilities",
+            "features": "/ztf/v1/objects/%s/features",
+            "single_feature": "/ztf/v1/objects/%s/features/%s",
+            "classifiers": "/ztf/v1/classifiers",
+            "classifier_classes": "/ztf/v1/classifiers/%s/%s/classes",
+            "forced_photometry": "/v2/lightcurve/forced-photometry/%s"
         }
     },
     "stamps": {

--- a/alerce/ztf_search.py
+++ b/alerce/ztf_search.py
@@ -162,7 +162,7 @@ class ZTFSearch(Client):
         """
         q = self._request(
             "GET",
-            "https://api.alerce.online/v2/lightcurve/forced-photometry/%s" % oid,
+            self.__get_url("forced_photometry", oid),
             result_format=format,
         )
 


### PR DESCRIPTION


## Description

This PR moves the forced_photometry function URL configuration to the default config file for testing purposes.

## Related Issue or Feature
<!--- This project only accepts pull requests related to open issues / features -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
This fix is related to the PR #75

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This change is require because is a refactor of the forced_photometry function.
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
The integration tests were not modified. All tests pass except for the two that were already failing.
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
